### PR TITLE
Remove tsx usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1479,18 +1479,6 @@
 				"source-map": "^0.6.1"
 			}
 		},
-		"node_modules/get-tsconfig": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
-			"integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
-			"dev": true,
-			"dependencies": {
-				"resolve-pkg-maps": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-			}
-		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1586,15 +1574,6 @@
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
 			"dev": true,
 			"license": "Unlicense"
-		},
-		"node_modules/resolve-pkg-maps": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
 		},
 		"node_modules/semver": {
 			"version": "7.7.2",
@@ -1696,26 +1675,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
 			"dev": true
-		},
-		"node_modules/tsx": {
-			"version": "4.20.0",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.0.tgz",
-			"integrity": "sha512-TsmdeXxcZYiJ2MKV7fdq38na0CKyLRtCeMqTeHMmrVXQ/gf5yTeJohh+sgr7MnMGsjeKXzHzy+TwOOTR1arl+Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esbuild": "~0.25.0",
-				"get-tsconfig": "^4.7.5"
-			},
-			"bin": {
-				"tsx": "dist/cli.mjs"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			}
 		},
 		"node_modules/typescript": {
 			"version": "5.8.3",
@@ -1890,7 +1849,6 @@
 				"@types/node": "^24.0.0",
 				"@whatwg-node/server": "^0.10.10",
 				"itty-router": "^5.0.18",
-				"tsx": "^4.20.0",
 				"typescript": "^5.8.3",
 				"wrangler": "^4.19.1"
 			}
@@ -1900,7 +1858,6 @@
 			"version": "0.0.0",
 			"devDependencies": {
 				"@types/node": "^24.0.0",
-				"tsx": "^4.20.0",
 				"typescript": "^5.8.3"
 			}
 		},
@@ -1913,7 +1870,6 @@
 			},
 			"devDependencies": {
 				"@types/node": "^24.0.0",
-				"tsx": "^4.20.0",
 				"typescript": "^5.8.3"
 			}
 		}

--- a/packages/cf/package.json
+++ b/packages/cf/package.json
@@ -7,8 +7,8 @@
 		"deploy": "wrangler --env prod deploy",
 		"deploy-preview": "wrangler deploy --dry-run --outdir dist",
 
-		"test": "tsx --tsconfig tsconfig.json --test '**/*.test.ts'",
-		"test-only": "tsx --tsconfig tsconfig.json --test --test-only '**/*.test.ts'",
+		"test": "node --test",
+		"test-only": "node --test --test-only",
 
 		"typecheck": "npm run typecheck-prod && npm run typecheck-test",
 		"typecheck-prod": "tsc",
@@ -20,7 +20,6 @@
 		"@types/node": "^24.0.0",
 		"@whatwg-node/server": "^0.10.10",
 		"itty-router": "^5.0.18",
-		"tsx": "^4.20.0",
 		"typescript": "^5.8.3",
 		"wrangler": "^4.19.1"
 	},

--- a/packages/ivoox/package.json
+++ b/packages/ivoox/package.json
@@ -4,8 +4,8 @@
 	"description": "",
 	"private": true,
 	"scripts": {
-		"test": "tsx --tsconfig ./tsconfig.json --test '**/*.test.ts'",
-		"test-only": "tsx --tsconfig ./tsconfig.json --test --test-only '**/*.test.ts'",
+		"test": "node --test",
+		"test-only": "node --test --test-only",
 		"typecheck": "npm run typecheck-prod && npm run typecheck-test",
 		"typecheck-prod": "tsc",
 		"typecheck-test": "tsc --project tsconfig.test.json"
@@ -13,7 +13,6 @@
 	"type": "module",
 	"devDependencies": {
 		"@types/node": "^24.0.0",
-		"tsx": "^4.20.0",
 		"typescript": "^5.8.3"
 	}
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,6 @@
 	"type": "module",
 	"devDependencies": {
 		"@types/node": "^24.0.0",
-		"tsx": "^4.20.0",
 		"typescript": "^5.8.3"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary
- replace `tsx` with Node's built-in TypeScript runner
- remove `tsx` dev dependency

## Testing
- `npm ci`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_e_68494425b58083278b1d87e58c35289a