### PR TITLE
Use wrangler types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 *.iml
 node_modules/
+.wrangler/
+packages/cf/worker-configuration.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,7 +289,9 @@
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250613.0.tgz",
 			"integrity": "sha512-upH6pxh43ph9293aXVgEp/0ODhyT3deRdlL0NEe4eJJdgoSAJxWj0c2ASZHs3awOaItRTxTxo7GZk1d6wolPKQ==",
 			"dev": true,
-			"license": "MIT OR Apache-2.0"
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
@@ -1886,7 +1888,6 @@
 				"@ivooxrss/server": "*"
 			},
 			"devDependencies": {
-				"@cloudflare/workers-types": "^4.20250613.0",
 				"@types/node": "^24.0.1",
 				"@whatwg-node/server": "^0.10.10",
 				"itty-router": "^5.0.18",

--- a/packages/cf/package.json
+++ b/packages/cf/package.json
@@ -11,12 +11,11 @@
 		"test-only": "tsx --tsconfig tsconfig.json --test --test-only '**/*.test.ts'",
 
 		"typecheck": "npm run typecheck-prod && npm run typecheck-test",
-		"typecheck-prod": "tsc",
+		"typecheck-prod": "wrangler types && tsc",
 		"typecheck-test": "tsc --project tsconfig.test.json"
 	},
 	"type": "module",
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20250613.0",
 		"@types/node": "^24.0.1",
 		"@whatwg-node/server": "^0.10.10",
 		"itty-router": "^5.0.18",

--- a/packages/cf/tsconfig.json
+++ b/packages/cf/tsconfig.json
@@ -2,7 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"extends": "../server/tsconfig.json",
 	"compilerOptions": {
-		"types": ["@cloudflare/workers-types"]
+		"types": ["./worker-configuration.d.ts"]
 	},
 	"include": ["*.ts"],
 	"exclude": ["*.test.ts"]


### PR DESCRIPTION
## Summary
- generate worker types with `wrangler types`
- remove `@cloudflare/workers-types` dependency
- ignore generated types

## Testing
- `npm ci`
- `just ci` *(fails: Could not find test files)*

------
https://chatgpt.com/codex/tasks/task_e_684facbd6c088327ab722adbeb2efa48