### PR TITLE
Remove tsx runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1481,18 +1481,6 @@
 				"source-map": "^0.6.1"
 			}
 		},
-		"node_modules/get-tsconfig": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
-			"integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
-			"dev": true,
-			"dependencies": {
-				"resolve-pkg-maps": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-			}
-		},
 		"node_modules/glob-to-regexp": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -1588,15 +1576,6 @@
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
 			"dev": true,
 			"license": "Unlicense"
-		},
-		"node_modules/resolve-pkg-maps": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
 		},
 		"node_modules/semver": {
 			"version": "7.7.2",
@@ -1698,26 +1677,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
 			"integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
 			"dev": true
-		},
-		"node_modules/tsx": {
-			"version": "4.20.3",
-			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
-			"integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esbuild": "~0.25.0",
-				"get-tsconfig": "^4.7.5"
-			},
-			"bin": {
-				"tsx": "dist/cli.mjs"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			}
 		},
 		"node_modules/typescript": {
 			"version": "5.8.3",
@@ -1891,7 +1850,6 @@
 				"@types/node": "^24.0.1",
 				"@whatwg-node/server": "^0.10.10",
 				"itty-router": "^5.0.18",
-				"tsx": "^4.20.3",
 				"typescript": "^5.8.3",
 				"wrangler": "^4.20.0"
 			}
@@ -1901,7 +1859,6 @@
 			"version": "0.0.0",
 			"devDependencies": {
 				"@types/node": "^24.0.1",
-				"tsx": "^4.20.3",
 				"typescript": "^5.8.3"
 			}
 		},
@@ -1914,7 +1871,6 @@
 			},
 			"devDependencies": {
 				"@types/node": "^24.0.1",
-				"tsx": "^4.20.3",
 				"typescript": "^5.8.3"
 			}
 		}

--- a/packages/cf/package.json
+++ b/packages/cf/package.json
@@ -6,10 +6,8 @@
 	"scripts": {
 		"deploy": "wrangler --env prod deploy",
 		"deploy-preview": "wrangler deploy --dry-run --outdir dist",
-
-		"test": "tsx --tsconfig tsconfig.json --test '**/*.test.ts'",
-		"test-only": "tsx --tsconfig tsconfig.json --test --test-only '**/*.test.ts'",
-
+		"test": "node --test",
+		"test-only": "node --test --test-only",
 		"typecheck": "npm run typecheck-prod && npm run typecheck-test",
 		"typecheck-prod": "wrangler types && tsc",
 		"typecheck-test": "tsc --project tsconfig.test.json"
@@ -19,7 +17,6 @@
 		"@types/node": "^24.0.1",
 		"@whatwg-node/server": "^0.10.10",
 		"itty-router": "^5.0.18",
-		"tsx": "^4.20.3",
 		"typescript": "^5.8.3",
 		"wrangler": "^4.20.0"
 	},

--- a/packages/cf/worker.ts
+++ b/packages/cf/worker.ts
@@ -1,5 +1,5 @@
-import { mkFetch } from "@ivooxrss/server/handler.js";
-import * as logger from "@ivooxrss/server/logger.js";
+import { mkFetch } from "@ivooxrss/server/handler.ts";
+import * as logger from "@ivooxrss/server/logger.ts";
 
 export default (<ExportedHandler<Env>>{
 	fetch: (request, env, _ctx) => {

--- a/packages/ivoox/episode.test.ts
+++ b/packages/ivoox/episode.test.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from "node:assert";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { episodeStream } from "./episode.js";
-import type { FetchWithErr, OkResponse } from "./fetch.js";
+import { episodeStream } from "./episode.ts";
+import type { FetchWithErr, OkResponse } from "./fetch.ts";
 
 test("parseEpisodePage", async (t) => {
 	await t.test(testEpisodeAudio);

--- a/packages/ivoox/episode.ts
+++ b/packages/ivoox/episode.ts
@@ -1,4 +1,4 @@
-import type { FetchWithErr, OkResponse } from "./fetch.js";
+import type { FetchWithErr, OkResponse } from "./fetch.ts";
 
 export { type ParsedEpisodePage, type ParsedDownloadPage, episodeStream };
 

--- a/packages/ivoox/feed.test.ts
+++ b/packages/ivoox/feed.test.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from "node:assert";
 import { readFile } from "node:fs/promises";
 import { mock, test } from "node:test";
-import { convert } from "./feed.js";
-import type { OkResponse } from "./fetch.js";
+import { convert } from "./feed.ts";
+import type { OkResponse } from "./fetch.ts";
 
 test("feed", async (t) => {
 	await t.test(testConvert);

--- a/packages/ivoox/feed.ts
+++ b/packages/ivoox/feed.ts
@@ -1,4 +1,4 @@
-import type { FetchWithErr } from "./fetch.js";
+import type { FetchWithErr } from "./fetch.ts";
 
 export { type Config, convert };
 

--- a/packages/ivoox/package.json
+++ b/packages/ivoox/package.json
@@ -4,8 +4,8 @@
 	"description": "",
 	"private": true,
 	"scripts": {
-		"test": "tsx --tsconfig ./tsconfig.json --test '**/*.test.ts'",
-		"test-only": "tsx --tsconfig ./tsconfig.json --test --test-only '**/*.test.ts'",
+		"test": "node --test",
+		"test-only": "node --test --test-only",
 		"typecheck": "npm run typecheck-prod && npm run typecheck-test",
 		"typecheck-prod": "tsc",
 		"typecheck-test": "tsc --project tsconfig.test.json"
@@ -13,7 +13,6 @@
 	"type": "module",
 	"devDependencies": {
 		"@types/node": "^24.0.1",
-		"tsx": "^4.20.3",
 		"typescript": "^5.8.3"
 	}
 }

--- a/packages/ivoox/tsconfig.json
+++ b/packages/ivoox/tsconfig.json
@@ -4,13 +4,13 @@
 		"lib": ["ES2022", "dom"],
 		"module": "nodenext",
 		"target": "es2022",
-
 		"strict": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
 		"noEmit": true,
-		"types": []
+		"types": [],
+		"allowImportingTsExtensions": true
 	},
 	"include": ["*.ts"],
 	"exclude": ["*.test.ts"]

--- a/packages/server/episode-handler.ts
+++ b/packages/server/episode-handler.ts
@@ -1,9 +1,9 @@
-import { episodeStream } from "@ivooxrss/ivoox/episode.js";
+import { episodeStream } from "@ivooxrss/ivoox/episode.ts";
 import {
 	type FetchWithErr,
 	NotOk,
 	type OkResponse,
-} from "@ivooxrss/ivoox/fetch.js";
+} from "@ivooxrss/ivoox/fetch.ts";
 import { error } from "itty-router";
 
 export { type Config, episodeHandler };

--- a/packages/server/feed-handler.ts
+++ b/packages/server/feed-handler.ts
@@ -1,5 +1,5 @@
-import { convert } from "@ivooxrss/ivoox/feed.js";
-import { type FetchWithErr, NotOk } from "@ivooxrss/ivoox/fetch.js";
+import { convert } from "@ivooxrss/ivoox/feed.ts";
+import { type FetchWithErr, NotOk } from "@ivooxrss/ivoox/fetch.ts";
 import { error } from "itty-router";
 
 export { type Config, feedHandler };

--- a/packages/server/handler.ts
+++ b/packages/server/handler.ts
@@ -1,8 +1,8 @@
-import { mkFetchWithErr } from "@ivooxrss/ivoox/fetch.js";
+import { mkFetchWithErr } from "@ivooxrss/ivoox/fetch.ts";
 import { Router, error } from "itty-router";
-import { episodeHandler } from "./episode-handler.js";
-import { feedHandler } from "./feed-handler.js";
-import type { Logger } from "./logger.js";
+import { episodeHandler } from "./episode-handler.ts";
+import { feedHandler } from "./feed-handler.ts";
+import type { Logger } from "./logger.ts";
 
 export { type Config, mkFetch };
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,6 @@
 	"type": "module",
 	"devDependencies": {
 		"@types/node": "^24.0.1",
-		"tsx": "^4.20.3",
 		"typescript": "^5.8.3"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary
- drop tsx usage and call node directly
- update imports to use `.ts` extensions
- add `allowImportingTsExtensions` to tsconfig

## Testing
- `npm ci`
- `just ci`

------
https://chatgpt.com/codex/tasks/task_e_684fad1001fc8327b057833f15a06d2a