### PR TITLE
Fix Biome lint errors after migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
 	"version": "0.0.0",
 	"description": "",
 	"private": true,
-	"workspaces": ["packages/*"],
+	"workspaces": [
+		"packages/*"
+	],
 	"scripts": {
 		"ci-lint": "biome ci .",
-		"lint": "biome check --apply ."
+		"lint": "biome check --write ."
 	},
 	"author": "",
 	"license": "ISC",

--- a/packages/cf/worker.test.ts
+++ b/packages/cf/worker.test.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from "node:assert";
 import { readFile } from "node:fs/promises";
-import { type Server, createServer } from "node:http";
+import { createServer, type Server } from "node:http";
 import test from "node:test";
 import { createServerAdapter } from "@whatwg-node/server";
-import { Router, type RouterType, error, html } from "itty-router";
+import { error, html, Router, type RouterType } from "itty-router";
 import { type Unstable_DevWorker, unstable_dev } from "wrangler";
 
 test("worker", async (t) => {

--- a/packages/server/handler.ts
+++ b/packages/server/handler.ts
@@ -1,5 +1,5 @@
 import { mkFetchWithErr } from "@ivooxrss/ivoox/fetch.ts";
-import { Router, error } from "itty-router";
+import { error, Router } from "itty-router";
 import { episodeHandler } from "./episode-handler.ts";
 import { feedHandler } from "./feed-handler.ts";
 import type { Logger } from "./logger.ts";


### PR DESCRIPTION
## Summary
- run `biome check --write`
- update script to use `--write`
- sort imports

## Testing
- `npm ci`
- `just ci`


------
https://chatgpt.com/codex/tasks/task_e_685273d369208327b22b7f869ce1447b